### PR TITLE
Update default postgres user

### DIFF
--- a/profiles.example.yml
+++ b/profiles.example.yml
@@ -5,7 +5,7 @@ app-example-dbt:
       threads: 1
       host: 127.0.0.1
       port: 5432
-      user: postgres
+      user: ""
       pass: ""
       dbname: app_example_dbt
       schema: public


### PR DESCRIPTION
When I ran `dbt seed` using the example, I got an error saying the 

```
app-example-dbt git:(main) dbt seed
Running with dbt=0.19.0
Found 2 models, 0 tests, 0 snapshots, 0 analyses, 138 macros, 0 operations, 2 seed files, 0 sources, 0 exposures

ERROR: Database Error
  FATAL:  role "postgres" does not exist
```

I think locally I don't need a user or role to get started.